### PR TITLE
Added MS30 tag edit patches

### DIFF
--- a/AnvilClient/src/Client/Patches/Engine/EnginePatches.cpp
+++ b/AnvilClient/src/Client/Patches/Engine/EnginePatches.cpp
@@ -26,5 +26,41 @@ bool EnginePatches::Init()
 	else
 		WriteLog("could not find wasapi fmod fix.");
 
+	// tag edit patch 1
+	auto s_TagPatch1 = Utils::Util::FindPattern(reinterpret_cast<void *>(s_BaseAddress), s_BaseSize, "\x84\xC0\x75\xFF\x8D\x85\xFF\xFE\xFF\xFF\x68", "xxx?xx?xxxx");
+
+	if (s_TagPatch1)
+	{
+		auto s_Ret = Utils::Util::PatchAddressInMemory(s_TagPatch1 + 2, "\xEB", 1);
+
+		WriteLog("Tag Patch 1 %s.", (s_Ret ? "applied" : "not applied"));
+	}
+	else
+		WriteLog("could not find tag patch 1 fix.");
+
+	// tag edit patch 2
+	auto s_TagPatch2 = Utils::Util::FindPattern(reinterpret_cast<void *>(s_BaseAddress), s_BaseSize, "\x83\xC4\x0C\x3B\x03\x75", "xxxxxx");
+
+	if (s_TagPatch2)
+	{
+		auto s_Ret = Utils::Util::PatchAddressInMemory(s_TagPatch2 + 5, "\x90\x90", 2);
+
+		WriteLog("Tag Patch 2 %s.", (s_Ret ? "applied" : "not applied"));
+	}
+	else
+		WriteLog("could not find tag patch 2 fix.");
+
+	// tag edit patch 3
+	auto s_TagPatch3 = Utils::Util::FindPattern(reinterpret_cast<void *>(s_BaseAddress), s_BaseSize, "\xC6\x86\x90\x33\x00\x00\x01", "xxxxxxx");
+
+	if (s_TagPatch3)
+	{
+		auto s_Ret = Utils::Util::PatchAddressInMemory(s_TagPatch3 - 2, "\x90\x90", 2);
+
+		WriteLog("Tag Patch 3 %s.", (s_Ret ? "applied" : "not applied"));
+	}
+	else
+		WriteLog("could not find tag patch 3 fix.");
+
 	return true;
 }


### PR DESCRIPTION
This allows the MS30 build of Halo: Online to run with modified modified tags. Normally, the game will crash on startup if the tag's checksum is invalid.

Thanks @Lord-Zedd
